### PR TITLE
Clarified defn of mission

### DIFF
--- a/gcis.ttl
+++ b/gcis.ttl
@@ -766,7 +766,7 @@ gcis:hasCaption a owl:DatatypeProperty ;
 	
 gcis:Mission a owl:Class ;
 	rdfs:label "Mission" ;
-	rdfs:comment "An official job that a person or group of people with which is tasked." ;
+	rdfs:comment "An official job with which individual(s) and/or groups are tasked." ;
 	rdfs:subClassOf prov:Entity .
 
 gcis:Experiment a owl:Class ;


### PR DESCRIPTION
The previous definition for "mission" was grammatically incorrect.
