### PR TITLE
Clarified various definitions

### DIFF
--- a/gcis.ttl
+++ b/gcis.ttl
@@ -201,7 +201,7 @@ gcis:hasFinding a owl:ObjectProperty ;
 
 gcis:hasFigure a owl:ObjectProperty ;
 	rdfs:label "has figure" ;
-	rdfs:comment "A publication contains one or more graphical components which most times but not necessarily contain a title and caption ."; 
+	rdfs:comment "A publication contains one or more graphical components which most times but not necessarily are numbered and contain titles and captions ."; 
 	rdfs:domain gcis:Publication ;
 	rdfs:range gcis:Figure ;
 	rdfs:subPropertyOf dcterms:hasPart .
@@ -222,14 +222,14 @@ gcis:worksAt a owl:ObjectProperty ;
 
 gcis:hasImage a owl:ObjectProperty ;
 	rdfs:label "has image" ;
-	rdfs:comment "The graphical component of a Figure." ;
+	rdfs:comment "A figure contains a graphical component." ;
 	rdfs:domain gcis:Figure, gcis:Image ;
 	rdfs:range gcis:Image ;
 	rdfs:subPropertyOf dcterms:hasPart .
 
 gcis:hasArray a owl:ObjectProperty ;
 	rdfs:label "has array" ;
-	rdfs:comment "A table may consist of one or more arrays." ;
+	rdfs:comment "A table contains one more arrays." ;
 	rdfs:domain gcis:Table ;
 	rdfs:range gcis:Array ;
 	rdfs:subPropertyOf dcterms:hasPart .	
@@ -971,7 +971,7 @@ gcis:isChapterOf a owl:ObjectProperty ;
 
 gcis:isImageOf a owl:ObjectProperty ; 
 	rdfs:label "is image of" ;
-	rdfs:comment "An image is in one or more figures." ;
+	rdfs:comment "An image appears in one or more figures." ;
 	owl:inverseOf gcis:hasImage ;
 	rdfs:domain gcis:Image ;
 	rdfs:subPropertyOf dcterms:isPartOf .

--- a/gcis.ttl
+++ b/gcis.ttl
@@ -676,7 +676,7 @@ gcis:Image a owl:Class ;
 	
 gcis:Array a owl:Class ;
 	rdfs:label "Array" ;
-	rdfs:comment "A group of numbers, signs or values arranged in rows and columns." ;
+	rdfs:comment "A collection of numbers, signs or values arranged in rows and columns." ;
 	rdfs:subClassOf prov:Entity .	
 
 gcis:Software a owl:Class ;
@@ -971,21 +971,21 @@ gcis:isChapterOf a owl:ObjectProperty ;
 
 gcis:isImageOf a owl:ObjectProperty ; 
 	rdfs:label "is image of" ;
-	rdfs:comment "An image is in one or more figures or other images." ;
+	rdfs:comment "An image is in one or more figures." ;
 	owl:inverseOf gcis:hasImage ;
 	rdfs:domain gcis:Image ;
 	rdfs:subPropertyOf dcterms:isPartOf .
 	
 gcis:isArrayOf a owl:ObjectProperty ;
 	rdfs:label "is array of" ;
-	rdfs:comment "An array is in one or more tables." ;
+	rdfs:comment "An array appears in one or more tables." ;
 	owl:inverseOf gcis:hasArray ;
 	rdfs:domain gcis:Array ;
 	rdfs:subPropertyOf dcterms:isPartOf .	
 
 gcis:isFigureOf a owl:ObjectProperty ;
 	rdfs:label "is figure of" ;
-	rdfs:comment "A figure is in a publication." ;
+	rdfs:comment "A figure appears in a publication." ;
 	owl:inverseOf gcis:hasFigure ;
 	rdfs:domain gcis:Figure ;
 	rdfs:range gcis:Publication;
@@ -993,7 +993,7 @@ gcis:isFigureOf a owl:ObjectProperty ;
 
 gcis:isTableOf a owl:ObjectProperty ;
 	rdfs:label "is table of" ;
-	rdfs:comment "A table is in a publication." ;
+	rdfs:comment "A table appears in a publication." ;
 	owl:inverseOf gcis:hasTable ;
 	rdfs:domain gcis:Table ;
 	rdfs:range gcis:Publication;

--- a/gcis.ttl
+++ b/gcis.ttl
@@ -1001,7 +1001,7 @@ gcis:isTableOf a owl:ObjectProperty ;
 
 gcis:isFindingOf a owl:ObjectProperty ;
 	rdfs:label "is finding of" ;
-	rdfs:comment "A finding is described by a publication." ;
+	rdfs:comment "A finding is described and emphasized in a publication." ;
 	owl:inverseOf gcis:hasFinding ;
 	rdfs:domain gcis:Finding ;
 	rdfs:subPropertyOf dcterms:isPartOf .

--- a/gcis.ttl
+++ b/gcis.ttl
@@ -194,7 +194,7 @@ gcis:hasAuthor a owl:ObjectProperty ;
 	rdfs:subPropertyOf prov:wasAttributedTo .
 
 gcis:hasFinding a owl:ObjectProperty ;
-	rdfs:label "Has Finding" ;
+	rdfs:label "has finding" ;
 	rdfs:comment "A publication may contain findings." ;
 	rdfs:range gcis:Finding ;
 	rdfs:subPropertyOf dcterms:hasPart.


### PR DESCRIPTION
I've clarified some of the definitions in the gcis ontology concerning images, figures, arrays, and tables.  @zednis, please confirm at your convenience whether they properly express their being properties in-lieu of classes, and to avoid using a word in its definition where possible and sensical.  I adapted the previously stated definitions for these assuming they reflected such issues but I'd appreciate a quick revisit of them.
