### PR TITLE
literal comment of gcis:isSupportedBy

### DIFF
--- a/gcis.ttl
+++ b/gcis.ttl
@@ -1034,7 +1034,7 @@ gcis:hasSubOrganization a owl:ObjectProperty ;
 
 gcis:isSupportedBy a owl:ObjectProperty ;
 	rdfs:label "is supported by" ;
-	rdfs:comment "A finding is supported by or depicted in data, figures, models, model runs, software, etc.";
+	rdfs:comment "A finding may be supported by or depicted in a few resources, such as data, figures, models, and software, etc." ;
 	rdfs:domain gcis:Finding .	
 
 gcis:computingEnvironmentsUsed a owl:DatatypeProperty ;


### PR DESCRIPTION
updated to rdfs:comment "A finding may be supported by or depicted in a
few resources, such as data, figures, models, and software, etc."
