### PR TITLE
Author report unit test

### DIFF
--- a/t/data/gcis/06-author-report.ttl
+++ b/t/data/gcis/06-author-report.ttl
@@ -1,0 +1,251 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix gcis: <http://data.globalchange.gov/gcis.owl#> .
+@prefix fabio: <http://purl.org/spar/fabio/> .
+@prefix cito: <http://purl.org/spar/cito/> .
+@prefix biro: <http://purl.org/spar/biro/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   dcterms:identifier "energy-supply-and-use";
+   gcis:chapterNumber "4"^^xsd:integer;
+   dcterms:title "Energy Supply and Use"^^xsd:string;
+   bibo:doi "10.7930/J0BG2KWD";
+   gcis:hasURL "http://nca2014.globalchange.gov/report/sectors/energy"^^xsd:anyURI;
+   gcis:isChapterOf <http://data.globalchange.gov/report/nca3>;
+ 
+## Figure(s) contained within the chapter
+   gcis:hasFigure <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/figure/paths-of-hurricanes-katrina-and-rita-relative-to-oil-and-gas-production-facilities>;
+   gcis:hasFigure <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/figure/increase-in-cooling-demand-and-decrease-in-heating-demand>;
+   gcis:hasFigure <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/figure/cooling-degree-days>;
+   gcis:hasFigure <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/figure/projected-changes-in-seasonal-precipitation>;
+   gcis:hasFigure <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/figure/california-power-plants-potentially-at-risk-from-sea-level-rise>;
+
+## Table(s) contained within the chapter
+   gcis:hasTable <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/table/energy-regional-impacts>;
+   gcis:hasTable <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/table/energy-adaptation>;
+   gcis:hasTable <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/table/energy-supply-national-regional>;
+
+## Findings which emerged from the chapter
+   gcis:hasFinding <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/finding/weather-affects-energy-production>;
+   gcis:hasFinding <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/finding/net-energy-use-projected-to-increase>;
+   gcis:hasFinding <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/finding/available-water-constrains-energy>;
+   gcis:hasFinding <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/finding/sea-level-rise-affects-energy>;
+   gcis:hasFinding <http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use/finding/future-energy-systems>;
+
+   a gcis:Chapter, fabio:Chapter .
+
+## Here is a subset of references contained in this chapter:
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:isCitedBy <http://data.globalchange.gov/report/indicator-heating-cooling-degree-days>;
+   biro:isReferencedBy <http://data.globalchange.gov/reference/8b4b3a63-6816-4033-91c1-2987d216a1e4>.
+
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/aeo2008>;
+   biro:references <http://data.globalchange.gov/reference/4b3a36af-895d-4151-9fbc-206d991558cb>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/aeo2012>;
+   biro:references <http://data.globalchange.gov/reference/2af3709d-81eb-48b7-9183-afc6c27015ea>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/entergy-building-2010>;
+   biro:references <http://data.globalchange.gov/reference/30fa21f9-4b83-4af6-bad0-61684ad53f27>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/ipcc-ar4-wg1>;
+   biro:references <http://data.globalchange.gov/reference/c54b9473-cdc3-4f22-97a8-4df5253f9682>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/article/10.1007/s10584-007-9376-7>;
+   biro:references <http://data.globalchange.gov/reference/83265c54-8988-42a0-a194-11744d0e1742>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/article/10.1257/app.3.4.152>;
+   biro:references <http://data.globalchange.gov/reference/48d08f16-c2bb-4591-831d-22c262d869fb>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/article/10.1007/s10584-010-9857-y>;
+   biro:references <http://data.globalchange.gov/reference/09a21b7e-fc7a-42cf-b451-5158835e6e7a>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/article/10.1016/j.enpol.2011.09.016>;
+   biro:references <http://data.globalchange.gov/reference/b5558bf8-6c04-4011-8f1e-30ce8e0743b4>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/noaa-techreport-nesdis-142-1>;
+   biro:references <http://data.globalchange.gov/reference/2acefcdc-827f-4c52-a4d8-56fc73f8ed35>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/noaa-techreport-nesdis-142-2>;
+   biro:references <http://data.globalchange.gov/reference/b50d0bc7-8731-41e7-861c-b88b678f51d0>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/noaa-techreport-nesdis-142-3>;
+   biro:references <http://data.globalchange.gov/reference/95f2ea7d-12e3-4ed5-9247-7cf139db91a9>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/noaa-techreport-nesdis-142-4>;
+   biro:references <http://data.globalchange.gov/reference/994416dc-705b-4063-b8f5-bd3ed21d4a71>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/noaa-techreport-nesdis-142-5>;
+   biro:references <http://data.globalchange.gov/reference/966bf116-8d6d-41f2-96be-4b66d3e729db>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/noaa-techreport-nesdis-142-6>;
+   biro:references <http://data.globalchange.gov/reference/903f7ebb-9b60-4418-b617-593476cbcea5>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/noaa-techreport-nesdis-142-9>;
+   biro:references <http://data.globalchange.gov/reference/0ebef171-4903-4aa6-b436-2936da69f84e>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/ccsp-sap-2_1a-2007>;
+   biro:references <http://data.globalchange.gov/reference/6ac1aea5-6b76-46e1-822e-664cb3d11e9a>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/ipcc-srex>;
+   biro:references <http://data.globalchange.gov/reference/089d8050-f4c8-4d07-bc35-25bf61691be3>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/analysisgroup-infrastructurevulnerabilitygulfcoast-2006>;
+   biro:references <http://data.globalchange.gov/reference/733c1cfe-178e-401d-8f80-b8cec0bbc6b3>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/report/epri-wateruseelectricity2030tr-2011>;
+   biro:references <http://data.globalchange.gov/reference/2e002d5f-fcf1-4d2e-a8b9-7f672a26e5a1>.
+
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   cito:cites <http://data.globalchange.gov/article/10.1016/j.jeem.2007.10.001>;
+   biro:references <http://data.globalchange.gov/reference/54474252-8763-4f2f-bf28-042b3a9e7c40>.
+
+
+
+
+## Person and his/her role in the creation of the entity:
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   prov:qualifiedAttribution [
+      a prov:Attribution;
+      prov:agent <http://data.globalchange.gov/person/886>;
+      prov:hadRole <http://data.globalchange.gov/role_type/convening_lead_author>;
+      prov:actedOnBehalfOf <http://data.globalchange.gov/organization/conoco-phillips>;
+      ] .
+
+## Person and his/her role in the creation of the entity:
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   prov:qualifiedAttribution [
+      a prov:Attribution;
+      prov:agent <http://data.globalchange.gov/person/895>;
+      prov:hadRole <http://data.globalchange.gov/role_type/convening_lead_author>;
+      prov:actedOnBehalfOf <http://data.globalchange.gov/organization/analysis-group-consultants>;
+      ] .
+
+## Person and his/her role in the creation of the entity:
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   prov:qualifiedAttribution [
+      a prov:Attribution;
+      prov:agent <http://data.globalchange.gov/person/1010>;
+      prov:hadRole <http://data.globalchange.gov/role_type/lead_author>;
+      prov:actedOnBehalfOf <http://data.globalchange.gov/organization/california-energy-commission>;
+      ] .
+
+## Person and his/her role in the creation of the entity:
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   prov:qualifiedAttribution [
+      a prov:Attribution;
+      prov:agent <http://data.globalchange.gov/person/987>;
+      prov:hadRole <http://data.globalchange.gov/role_type/lead_author>;
+      prov:actedOnBehalfOf <http://data.globalchange.gov/organization/duke-university>;
+      ] .
+
+## Person and his/her role in the creation of the entity:
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   prov:qualifiedAttribution [
+      a prov:Attribution;
+      prov:agent <http://data.globalchange.gov/person/986>;
+      prov:hadRole <http://data.globalchange.gov/role_type/lead_author>;
+      prov:actedOnBehalfOf <http://data.globalchange.gov/organization/electric-power-research-institute>;
+      ] .
+
+## Person and his/her role in the creation of the entity:
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   prov:qualifiedAttribution [
+      a prov:Attribution;
+      prov:agent <http://data.globalchange.gov/person/4015>;
+      prov:hadRole <http://data.globalchange.gov/role_type/lead_author>;
+      prov:actedOnBehalfOf <http://data.globalchange.gov/organization/stanford-university>;
+      ] .
+
+## Person and his/her role in the creation of the entity:
+<http://data.globalchange.gov/report/nca3/chapter/energy-supply-and-use>
+   prov:qualifiedAttribution [
+      a prov:Attribution;
+      prov:agent <http://data.globalchange.gov/person/950>;
+      prov:hadRole <http://data.globalchange.gov/role_type/lead_author>;
+      prov:actedOnBehalfOf <http://data.globalchange.gov/organization/oak-ridge-national-laboratory>;
+      ] .
+
+
+<http://data.globalchange.gov/role_type/lead_author>
+   dcterms:identifier "lead_author";
+   rdfs:label "Lead Author";
+
+   a prov:Role .
+
+<http://data.globalchange.gov/person/950>
+   dcterms:identifier "950";
+   foaf:givenName "Thomas J."^^xsd:string;
+   foaf:lastName "Wilbanks"^^xsd:string;
+   foaf:page "http://www.esd.ornl.gov/people/wilbanks/"^^xsd:anyURI;
+   
+   a gcis:Person .
+
+<http://data.globalchange.gov/person/4015>
+   dcterms:identifier "4015";
+   foaf:givenName "John P."^^xsd:string;
+   foaf:lastName "Weyant"^^xsd:string;
+   foaf:page "https://profiles.stanford.edu/john-weyant"^^xsd:anyURI;
+   
+   a gcis:Person .
+
+<http://data.globalchange.gov/person/986>
+   dcterms:identifier "986";
+   foaf:givenName "Rich"^^xsd:string;
+   foaf:lastName "Richels"^^xsd:string;
+   foaf:page "http://eea.epri.com/research-staff.html"^^xsd:anyURI;
+   
+   a gcis:Person .
+
+<http://data.globalchange.gov/person/987>
+   dcterms:identifier "987";
+   foaf:givenName "Richard G."^^xsd:string;
+   foaf:lastName "Newell"^^xsd:string;
+   foaf:page "http://fds.duke.edu/db/Nicholas/esp/faculty/rgn3"^^xsd:anyURI;
+   
+   a gcis:Person .
+
+<http://data.globalchange.gov/person/1010>
+   dcterms:identifier "1010";
+   vivo:orcidId "0000-0001-6213-7748";
+   foaf:givenName "Guido"^^xsd:string;
+   foaf:lastName "Franco"^^xsd:string;
+   
+   a gcis:Person .
+
+<http://data.globalchange.gov/person/895>
+   dcterms:identifier "895";
+   foaf:givenName "Susan"^^xsd:string;
+   foaf:lastName "Tierney"^^xsd:string;
+   
+   a gcis:Person .
+
+<http://data.globalchange.gov/person/886>
+   dcterms:identifier "886";
+   foaf:givenName "Jan"^^xsd:string;
+   foaf:lastName "Dell"^^xsd:string;
+   
+   a gcis:Person .

--- a/t/results/06-author-report.csv
+++ b/t/results/06-author-report.csv
@@ -1,0 +1,6 @@
+ContributorID,Name,Role,ChapterName,ChapterNumber
+http://data.globalchange.gov/person/1010,"Franco, Guido",Lead Author,Energy Supply and Use,4
+http://data.globalchange.gov/person/4015,"Weyant, John P.",Lead Author,Energy Supply and Use,4
+http://data.globalchange.gov/person/950,"Wilbanks, Thomas J.",Lead Author,Energy Supply and Use,4
+http://data.globalchange.gov/person/986,"Richels, Rich",Lead Author,Energy Supply and Use,4
+http://data.globalchange.gov/person/987,"Newell, Richard G.",Lead Author,Energy Supply and Use,4

--- a/t/sparql/06-author-report.sparql
+++ b/t/sparql/06-author-report.sparql
@@ -1,0 +1,26 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX gcis: <http://data.globalchange.gov/gcis.owl#>
+PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dbpprop: <http://dbpedia.org/property/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+SELECT DISTINCT
+  ?ContributorID ?Name ?Role ?ChapterName ?ChapterNumber
+WHERE {
+  <http://data.globalchange.gov/report/nca3> gcis:hasChapter ?chapter .
+  ?chapter dcterms:title ?cht .
+  ?chapter gcis:chapterNumber ?cn .
+  ?chapter prov:qualifiedAttribution [ prov:hadRole ?role ; prov:agent ?author ] .
+  ?role rdfs:label ?rlabel .
+  ?author foaf:givenName ?gn .
+  ?author foaf:lastName ?ln .
+  BIND(?author AS ?ContributorID)
+  BIND(CONCAT(str(?ln), ", ", str(?gn)) AS ?Name)
+  BIND(str(?rlabel) AS ?Role)
+  BIND(str(?cht) AS ?ChapterName)
+  BIND(str(?cn) AS ?ChapterNumber)
+} order by ?ContributorID


### PR DESCRIPTION
references #113.  Added author report unit test.  I had to make modifications to the query because of incompatibilities in virtuoso and jena query syntax support.

@bduggan when I run ./run-tests.sh it shows the following for this test:

```
not ok 7 - 06-author-report.sparql
```

but a diff shows no difference between the expected results and the results in tmp

```
$ diff t/results/06-author-report.csv /tmp/06-author-report.csv 
```
